### PR TITLE
Added support to build our sponsor list from the meetup API

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -9,13 +9,7 @@
     
     %div.sponsors
       %h3 Support Our Sponsors
-      = link_to image_tag('stickermule.png', :height => '90', :width => '90'),
-          'http://www.stickermule.com/unlock?ref_id=6020568601'
-
-      = link_to image_tag('busyconf.png', :height => '90', :width => '90'),
-          'http://busyconf.com'
-
-      = link_to image_tag('customink_logo.jpg', :height => '90', :width => '90'), 'http://www.customink.com'
+      %div#sponsors
 
   %ul#events.span5.offset1
 
@@ -28,3 +22,6 @@
       .rsvp attending: {{yes_rsvp_count}}
       .description {{description}}
 
+  %script#sponsor-template{ type: 'text/x-handlebars-template' }
+    %a{href: "{{url}}" } 
+      %img.sponsor{ src: "{{image_url}}"}

--- a/source/javascripts/sponsors.js.coffee
+++ b/source/javascripts/sponsors.js.coffee
@@ -1,0 +1,18 @@
+class SponsorsView
+  constructor: ->
+    @source = $("#sponsor-template").html()
+    @template = Handlebars.compile(@source)
+
+  get_sponsors: ->
+    url = "http://api.meetup.com/2/groups?group_id=8825222&radius=25.0&order=id&desc=false&offset=0&format=json&page=500&fields=sponsors&sig_id=13745894&sig=288da9174a8ce352ee1bdc0af34013592d49f612&callback=loadSponsors"
+    $.ajax url,
+        dataType: 'jsonp'
+        success: (data) =>
+          @add_sponsor sponsor for sponsor in data.results[0].sponsors
+
+  add_sponsor: (sponsor) ->
+    $("#sponsors").append @template(sponsor)
+
+$ ->
+  sponsors_view = new SponsorsView
+  sponsors_view.get_sponsors()

--- a/source/stylesheets/all.css.sass
+++ b/source/stylesheets/all.css.sass
@@ -59,3 +59,5 @@ a:hover
 
 .sponsors
   margin-top: $line-height-normal
+  .sponsor
+    padding: 1em


### PR DESCRIPTION
I've added support to build our sponsor list using the Meetup API.  This is working great, two things we may want to consider:
- Using just the "die cut" style logos on meetup.  Seeing just the logo looks better on the RubyLoCo site (instead of the logo w/ the company name).
- Using a proper logo for Chase (or possibly removing him as a sponsor). It's comical to see his head on the page, but also not flattering for the site.
