### PR TITLE
centered the logo in the left column

### DIFF
--- a/source/stylesheets/all.css.sass
+++ b/source/stylesheets/all.css.sass
@@ -40,7 +40,8 @@ a:hover
 
 /** Page Styles **/
 #rubyloco-logo
-  float: left
+  display: block
+  margin: auto
 #events
   float: left
   li


### PR DESCRIPTION
Logo is now centered. Also the text was wrapping around on my screen, this is also now resolved.
