### PR TITLE
Event word wrapping and white space utilization

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -20,14 +20,16 @@
 
   %script#event-template{ type: 'text/x-handlebars-template' }
     %li.event
-      %a{ href: "{{event_url}}", class: "event-thumb" }
-        %img{ src: "{{thumb_src}}" }
       %div.event-details
+        %a{ href: "{{event_url}}", class: "event-thumb" }
+          %img{ src: "{{thumb_src}}" }
         %a{ href: "{{event_url}}", class: "event-name" }
           %h2.name {{name}}
         %description {{description}}
         %div.meta
-          when: {{date}} | where: {{venue.name}} | attending: {{yes_rsvp_count}}
+          %span="when: <strong>{{date}}</strong> |"
+          %span="where: <strong>{{venue.name}}</strong> |"
+          %span="attending: <strong>{{yes_rsvp_count}}</strong>"
       %div{ class: "list-item-footer"}
 
   %script#sponsor-template{ type: 'text/x-handlebars-template' }

--- a/source/stylesheets/all.css.sass
+++ b/source/stylesheets/all.css.sass
@@ -93,24 +93,23 @@ h3.list-header
       display: block
       a.event-thumb
         float: left
-        padding-top: 15px
+        margin-right: 15px
         img
           width: 60px
           height: 60px
       .event-details
-        width: 410px
-        margin-left: 20px
         float: left
         font-size: 13px
         .name
           display: block
-          color: black
           margin: 0px
+          margin-bottom: 10px
           font-size: 15px
+          line-height: 20px
           color: #2e3639
         .meta
           span
-            font-weight: bold
+            white-space: nowrap
         .description  
           display: block
           font-size: 13px


### PR DESCRIPTION
Event details were running outside of the #events container 
and the giant white space next to the .event-thumb looked strange
to me.
