### PR TITLE
Move the RSVP button to a block elem

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -12,7 +12,6 @@
     .event-details
       %h2.name
         %a{ href: "{{event_url}}", class: "event-name" } {{name}}
-      %a{ href: "{{event_url}}", class: "btn btn-primary rsvp" } RSVP
       .description {{description}}
       .meta
         %span when: <strong>{{date}}</strong>
@@ -20,3 +19,5 @@
         %span where: <strong>{{venue.name}}</strong>
         |
         %span attending: <strong>{{yes_rsvp_count}}</strong>
+      <br />
+      %a{ href: "{{event_url}}", class: "btn btn-block btn-primary rsvp" } RSVP


### PR DESCRIPTION
The RSVP currently is just kind of floating, by turning it into a block we can create a base for the item and ensure the button is in a consistent location.

![screen shot 2015-02-10 at 9 29 56 am](https://cloud.githubusercontent.com/assets/947110/6128849/7de6e0ee-b107-11e4-8d45-00075b92614c.png)
