### PR TITLE
Enhance accessibility through ARIA

### DIFF
--- a/source/about.html.haml
+++ b/source/about.html.haml
@@ -1,5 +1,5 @@
 %h3.list-header
-  %i.icon-lightbulb.icon-large.icon-fixed-width
+  %i{class: "icon-lightbulb icon-large icon-fixed-width", aria: {hidden: "true"}}
   About #{data.site.name}
 #about.list-body
   %article.intro
@@ -12,11 +12,11 @@
     %p
       #{link_to "Follow Us", "http://twitter.com/ruby_loco"} on Twitter for details about our next hack night and meetup.
 
-    %h4 Organizers
+    %h4#organizers Organizers
 
     .members
       - data.members.each do |member|
-        .span3.text-center.member
-          = image_tag "http://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(member.email)}", class: 'img-circle'
+        %div{class: "span3 text-center member", aria: {labelledby: "organizers"}}
+          = image_tag "http://www.gravatar.com/avatar/#{Digest::MD5.hexdigest(member.email)}", class: 'img-circle', alt: "Photo of #{member.name}"
           .name= member.name
-          .twitter= link_to "@#{member.twitter}", "http://twitter.com/#{member.twitter}"
+          .twitter= link_to "@#{member.twitter}", "http://twitter.com/#{member.twitter}", aria: {label: "View #{member.name} on Twitter as @#{member.twitter}"}

--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -1,5 +1,5 @@
-%h3.list-header
-  %i.icon-bullhorn.icon-large.icon-fixed-width
+%h3{class: "list-header", role: "main"}
+  %i{class: "icon-bullhorn icon-large icon-fixed-width", aria: {hidden: "true"}}
   Upcoming Events
 #events.list-body
   .text-center.muted
@@ -8,11 +8,11 @@
 %script#event-template{ type: 'text/x-handlebars-template' }
   .event
     = link_to "{{event_url}}", class: "thumb" do
-      %img{ src: "{{thumb_src}}" }
+      %img{ src: "{{thumb_src}}", alt: "Ruby Loco Skull Logo" }
     .event-details
       %h2.name
-        %a{ href: "{{event_url}}", class: "event-name" } {{name}}
-      %a{ href: "{{event_url}}", class: "btn btn-primary rsvp" } RSVP
+        %a{ href: "{{event_url}}", class: "event-name",   aria: { label: "{{name}} on {{date}}" }} {{name}}
+      %a{ href: "{{event_url}}", role: "button", class: "btn btn-primary rsvp",  aria: { label: "RSVP — {{name}} on {{date}}" } } RSVP
       .description {{description}}
       .meta
         %span when: <strong>{{date}}</strong>

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -39,11 +39,11 @@
             .text-center.muted
               %i.icon-spinner.icon-spin.icon-jumbo
 
-    .navbar-fixed-bottom.footer.text-center
-      %ul.nav.inline
-        %li=link_to "Home", "/"
-        %li=link_to "About", "/about"
-        %li=link_to "Photos", "/photos"
+    %div{role: "navigation", class: "navbar-fixed-bottom footer text-center"}
+      %ul{role: "menu", class: "nav inline"}
+        %li{role: "menuitem"}=link_to "Home", "/"
+        %li{role: "menuitem"}=link_to "About", "/about"
+        %li{role: "menuitem"}=link_to "Photos", "/photos"
 
     = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/2.0.1/jquery.min.js"
     = javascript_include_tag "all.js"
@@ -51,4 +51,4 @@
 
     %script#sponsor-template{ type: 'text/x-handlebars-template' }
       %a{href: "{{url}}" }
-        %img.sponsor{ src: "{{image_url}}", data: { toggle: "tooltip", placement: "left", html: "true" }, title: "<strong>{{name}}</strong><br>{{info}}" }
+        %img.sponsor{ src: "{{image_url}}", alt: "{{name}} logo", data: { toggle: "tooltip", placement: "left", html: "true" }, title: "<strong>{{name}}</strong><br>{{info}}" }

--- a/source/photos.html.haml
+++ b/source/photos.html.haml
@@ -1,10 +1,10 @@
 %h3.list-header
-  %i.icon-camera-retro.icon-large.icon-fixed-width
+  %i{class: "icon-camera-retro icon-large icon-fixed-width", aria: {hidden: "true"}}
   Photos
-#photos.list-body
+%div{class: "list-body", id: "photos", role: "main"}
   .text-center.muted
     %i.icon-spinner.icon-spin.icon-jumbo
 
 %script#photo-template{ type: 'text/x-handlebars-template' }
-  %a{href: "{{highres_link}}" }
+  %a{href: "{{highres_link}}", aria: {label: "View High-Resolution Image"} }
     %img.photo{ src: "{{photo_link}}", data: { toggle: "tooltip", placement: "bottom", html: "true" }, title: "Uploaded on {{date}} by {{member.name}}" }


### PR DESCRIPTION
This pull request focuses on making additions to the site based on the W3C recommendations for ARIA, short for Accessible Rich Internet Applications, which defines ways to make Web content and Web applications (especially those developed with Ajax and JavaScript) more accessible to people with disabilities.

This includes adding more descriptive labels to similar links such as RSVP links, alt tags on images, roles of items such as navigation, menu, setting `aria-hidden` to true for icons, etc.